### PR TITLE
Updating to support iOS 6

### DIFF
--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -451,7 +451,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0450;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sqlcipher" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -515,6 +515,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -536,13 +537,6 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 				);
-				"OTHER_CFLAGS[arch=armv6]" = (
-					"-mno-thumb",
-					"-DSQLITE_HAS_CODEC",
-					"-DNDEBUG",
-					"-DSQLITE_TEMP_STORE=2",
-					"-DSQLITE_THREADSAFE",
-				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = sqlcipher;
 			};
@@ -552,6 +546,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				HEADER_SEARCH_PATHS = (
@@ -572,14 +567,6 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 				);
-				"OTHER_CFLAGS[arch=armv6]" = (
-					"-mno-thumb",
-					"-DSQLITE_HAS_CODEC",
-					"-DNDEBUG",
-					"-DSQLITE_OS_UNIX=1",
-					"-DSQLITE_TEMP_STORE=2",
-					"-DSQLITE_THREADSAFE",
-				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = sqlcipher;
 			};
@@ -589,8 +576,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphoneos*]" = (
-					armv6,
 					armv7,
+					armv7s,
 				);
 				"ARCHS[sdk=macosx*]" = (
 					x86_64,
@@ -612,8 +599,8 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"ARCHS[sdk=iphoneos*]" = (
-					armv6,
 					armv7,
+					armv7s,
 				);
 				"ARCHS[sdk=macosx*]" = (
 					x86_64,
@@ -631,6 +618,7 @@
 		9069D08C0FCE185A0042E34C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -641,6 +629,7 @@
 		9069D08D0FCE185A0042E34C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				PRODUCT_NAME = amalgamation;


### PR DESCRIPTION
As with openssl, this will _not_ be able to be rebuilt from source with versions of Xcode less than 4.5, because of the cross-platform issues.  And as with the other project, the build of this is more explicitly off the beaten path (i.e. the user won't run into inadvertent rebuilds with install.sh), so we should be okay.
