### PR TITLE
Changes to create a bitcode-for-archive library

### DIFF
--- a/build_for_sdk.sh
+++ b/build_for_sdk.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-xcodebuild ARCHS="armv7 armv7s arm64" ONLY_ACTIVE_ARCH=NO -configuration Release -project sqlcipher.xcodeproj
-xcodebuild ARCHS="x86_64 i386" ONLY_ACTIVE_ARCH=NO -configuration Release -project sqlcipher.xcodeproj -sdk iphonesimulator
-lipo -create build/Release-iphoneos/libsqlcipher.a build/Release-iphonesimulator/libsqlcipher.a -output libsqlcipher.a
+xcodebuild ARCHS="armv7 armv7s arm64" ONLY_ACTIVE_ARCH=NO PLATFORM_NAME=iphoneos -configuration Release -project sqlcipher.xcodeproj -target sqlcipher clean install
+xcodebuild ARCHS="x86_64 i386" ONLY_ACTIVE_ARCH=NO PLATFORM_NAME=iphonesimulator -configuration Release -sdk iphonesimulator -project sqlcipher.xcodeproj -target sqlcipher clean install
+lipo -create build/UninstalledProducts/iphoneos/libsqlcipher.a build/UninstalledProducts/iphonesimulator/libsqlcipher.a -output libsqlcipher.a


### PR DESCRIPTION
If you're consuming the current version of libsqlcipher.a in your app, you cannot archive your app from Xcode.  E.g. you will receive the following error when trying to archive the SmartSyncExplorer sample app in the Mobile SDK:

```
ld: bitcode bundle could not be generated because '/Users/khawkins/git/kh_ios_sdk/external/ThirdPartyDependencies/sqlcipher/libsqlcipher.a(sqlite3.o)' was built without full bitcode. All object files and libraries for bitcode must be generated from Xcode Archive or Install build for architecture arm64
```

Changing the script here to `xcodebuild install` the library, then lipo the results from the installation destination folders.